### PR TITLE
confirmation_pay_fee

### DIFF
--- a/app/views/confirmation_pay_fee/start.html
+++ b/app/views/confirmation_pay_fee/start.html
@@ -1,0 +1,69 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Tax tribunal lodgement fee - Tax Tribunals Prototype
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+  {% include "includes/phase_banner_alpha.html" %}
+
+  <p>Step X of Y</p>
+  <div class="govuk-box-highlight">
+    <h2 class="bold-large">Your appeal has been submited to the tax tribunal.</h2>
+    <br>
+    <h2>Your reference is:
+      <span class="display-block fee-display">
+        <span class="write-value" data-key="fee">TC/2016/123456</span>
+      </span>
+    </h2>
+ </div>
+ <div>
+    <h1 class="heading-large">Please arrange payment of your tribunal fee</h1>
+
+    <p class="lede">Select your method of payment</p>
+  
+    <form class="js_route" action="../payment_tool/case_to_pay">
+        <fieldset>
+          <div class="form-group">
+            <label class="block-label">
+              <input name="dispute_type" type="radio" value="debit_credit_card" />
+              Debit or credit card
+            </label>
+
+            <label class="block-label">
+              <input name="dispute_type" type="radio" value="help_with_fees" />
+              Help with fees
+            </label>
+
+            <label class="block-label">
+              <input name="dispute_type" type="radio" value="out_of_time_request" data-store="fee=50" />
+              Account
+            </label>
+
+            <label class="block-label">
+              <input name="dispute_type" type="radio" value="close_ongoing_enquiry" data-store="fee=50" />
+              Cheque
+            </label>
+
+          </div>
+        </fieldset>
+
+        <p>
+          <input class="button" type="submit" value="Continue">
+        </p>
+
+      </form>
+
+      <details>
+        <summary>Help with types of appeal</summary>
+        <div class="panel">
+          <p>You can only choose one reason per appeal. For example if you wanted to appeal against both a penalty and the amount you owe, you will need to make two separate appeals to the tax tribunal.</p>
+        </div>
+      </details>
+ </div>
+</main>
+
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -17,6 +17,7 @@
     <li><a href="/before_you_start/start">"Before you start"</a></li>
     <li><a href="/expandables/start">"Expandables" demo</a></li>
     <li><a href="/data_capture/start">Data capture</a></li>
+    <li><a href="/confirmation_pay_fee/start">Confirmation and Pay Fee</a></li>
   </ul>
 
 </main>


### PR DESCRIPTION
adding option on start page list which displays the confirmation page
(the page the appellant sees when they agree declaration and submit
their appeal/application)

the page’s credit card option then links to the fee payment tool. the
other pages are yet to be created.
