### PR TITLE
remove noisy logs from console, dump data on ESC

### DIFF
--- a/app/assets/javascripts/module_loader.js
+++ b/app/assets/javascripts/module_loader.js
@@ -12,7 +12,6 @@
     init: function() {
       for (var x in moj.Modules) {
         if (typeof moj.Modules[x].init === 'function') {
-          moj.log('Initialising "' + x + '" module');
           moj.Modules[x].init();
         }
       }

--- a/app/assets/javascripts/modules/data-store.js
+++ b/app/assets/javascripts/modules/data-store.js
@@ -8,14 +8,34 @@ moj.Modules.dataStore = {
     for (var i = storedLength - 1; i >= 0; i--) {
       if($('body').hasClass('clear-session')) {
         self.deleteItem(sessionStorage.key(i));
-      } else {
-        moj.log('RETRIEVED: ' + sessionStorage.key(i) + ' = ' + sessionStorage.getItem(sessionStorage.key(i)));
       }
     }
+
+    self.bindEvents();
+  },
+
+  bindEvents: function() {
+    var self = this;
+
+    $(document).on('keyup', function(e) {
+      if(e.keyCode === 27) {
+        self.dumpData();
+      }
+    });
+  },
+
+  dumpData: function() {
+    var self = this,
+        storedLength = sessionStorage.length;
+
+    moj.log('*** session vars ***');
+    for(var i = 0; i < storedLength; i++) {
+      moj.log(sessionStorage.key(i) + ' = ' + sessionStorage.getItem(sessionStorage.key(i)));
+    }
+    moj.log('*** END session vars ***');
   },
 
   storeItem: function(key, value) {
-    moj.log('STORING: ' + key + '=' + value);
     sessionStorage.setItem(key, JSON.stringify(value));
   },
 
@@ -24,7 +44,6 @@ moj.Modules.dataStore = {
   },
 
   deleteItem: function(key) {
-    moj.log('DELETING: ' + key);
     sessionStorage.removeItem(key);
   },
 

--- a/app/assets/javascripts/modules/form-routes.js
+++ b/app/assets/javascripts/modules/form-routes.js
@@ -13,7 +13,6 @@ moj.Modules.formRoutes = {
     var self = this,
         $form = $('form.js_route').eq(0);
 
-    moj.log('js form routing');
     $form.on('submit', function(e) {
       e.preventDefault();
 


### PR DESCRIPTION
A lot of data was being logged out to console.log (via moj.log) on page load. This was harmless initially, but it then polluted the STDOUT of the smoke tests.

Now data in the session variables can be written out to console at any time by pressing ESC