### PR TITLE
debug panel

### DIFF
--- a/app/assets/javascripts/modules/data-store.js
+++ b/app/assets/javascripts/modules/data-store.js
@@ -10,18 +10,6 @@ moj.Modules.dataStore = {
         self.deleteItem(sessionStorage.key(i));
       }
     }
-
-    self.bindEvents();
-  },
-
-  bindEvents: function() {
-    var self = this;
-
-    $(document).on('keyup', function(e) {
-      if(e.keyCode === 27) {
-        self.dumpData();
-      }
-    });
   },
 
   dumpData: function() {

--- a/app/assets/javascripts/modules/debug-panel.js
+++ b/app/assets/javascripts/modules/debug-panel.js
@@ -1,0 +1,50 @@
+'use strict';
+
+moj.Modules.debug = {
+  tools: [
+    {
+      text: 'log session vars',
+      call: 'moj.Modules.dataStore.dumpData();'
+    }
+  ],
+  init: function() {
+    var self = this;
+
+    self.bindEvents();
+  },
+
+  bindEvents: function() {
+    var self = this;
+
+    $(document).on('keyup', function(e) {
+      if(e.keyCode === 27) { // ESC
+        if(!e.shiftKey) { // show debug panel
+          self.debugPanel();
+        } else { // shift+ESC shortcut to dump session vars to console
+          moj.Modules.dataStore.dumpData();
+        }
+      }
+    });
+
+    $(document).on('click', '#debugPanel li.link' , function(e) {
+      var $el = $(e.target),
+          call = new Function($el.data('call'));
+
+      return (call());
+    });
+  },
+
+  debugPanel: function() {
+    var self = this;
+
+    if(!$('#debugPanel').length) {
+      $('body').prepend('<div id="debugPanel"><h2>TOOLS</h2><ul></ul></div>');
+
+      self.tools.forEach(function(tool) {
+        $('#debugPanel ul').append('<li class="link" data-call="' + tool.call + '">' + tool.text + '</li>');
+      });
+    } else {
+      $('#debugPanel').toggle();
+    }
+  }
+};

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -21,6 +21,8 @@ $path: "/public/images/";
 @import 'local/dropzone';
 @import 'local/utilities';
 
+@import 'local/debug';
+
 // Related items
 // (These styles will be moved to GOV.UK elements, duplicating here for now.)
 .govuk-related-items {

--- a/app/assets/sass/local/debug.scss
+++ b/app/assets/sass/local/debug.scss
@@ -1,0 +1,19 @@
+#debugPanel {
+  position: fixed;
+  right: 4px;
+  top: 4px;
+  width: 150px;
+  padding: 5px;
+  background-color: $white;
+  border: 2px solid $yellow;
+
+  h2 {
+    text-align: center;
+    font-weight: bold;
+    margin-bottom: 1em;
+  }
+
+  li {
+    cursor: pointer;
+  }
+}

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -10,6 +10,7 @@
 <!-- load and init() modules based on moj Heisenberg pattern -->
 <script src="/public/javascripts/module_loader.js"></script>
 <!-- modules -->
+<script src="/public/javascripts/modules/debug-panel.js"></script>
 <script src="/public/javascripts/modules/back-links.js"></script>
 <script src="/public/javascripts/modules/link-alerts.js"></script>
 <script src="/public/javascripts/modules/paid-case.js"></script>


### PR DESCRIPTION
Bind ESC to show a little debug panel in top right corner rather than defaulting to console dump of variables.

This is in preparation for making validation switchable on/off.

![screen shot 2016-12-09 at 11 45 56](https://cloud.githubusercontent.com/assets/988436/21048052/207728c6-be05-11e6-90c4-4c11f0425394.png)

(Pro-tip: use shift+ESC as shortcut to dump vars to console without opening the panel.)